### PR TITLE
fix(meta): enable SSR and fix Open Graph metadata attributes

### DIFF
--- a/composables/useMetaData.js
+++ b/composables/useMetaData.js
@@ -9,11 +9,12 @@ const getMetaData = (route, meta) => {
     meta: [
       { name: 'title', content: `${meta.meta_title} - J.D. Hillen` },
       { name: 'description', content: meta.meta_description },
-      { name: 'og:type', content: 'website' },
-      { name: 'og:url', content: `${siteUrl}${route.fullPath}` },
-      { name: 'og:title', content: `${meta.meta_title} - J.D. Hillen` },
-      { name: 'og:description', content: meta.meta_description },
-      { name: 'og:image', content: meta.meta_image },
+      { property: 'og:type', content: 'website' },
+      { property: 'og:url', content: `${siteUrl}${route.fullPath}` },
+      { property: 'og:title', content: `${meta.meta_title} - J.D. Hillen` },
+      { property: 'og:description', content: meta.meta_description },
+      { property: 'og:image', content: meta.meta_image },
+      { property: 'og:site_name', content: 'J.D. Hillen' },
       { name: 'twitter:card', content: 'summary_large_image' },
       { name: 'twitter:site', content: '@jdhillen' },
       { name: 'twitter:creator', content: '@jdhillen' },
@@ -21,6 +22,9 @@ const getMetaData = (route, meta) => {
       { name: 'twitter:title', content: `${meta.meta_title} - J.D. Hillen` },
       { name: 'twitter:description', content: meta.meta_description },
       { name: 'twitter:image', content: meta.meta_image }
+    ],
+    link: [
+      { rel: 'canonical', href: `${siteUrl}${route.fullPath}` }
     ]
   };
   return obj;

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,6 +1,6 @@
 // https://v3.nuxtjs.org/api/configuration/nuxt.config
 export default defineNuxtConfig({
-  ssr: false,
+  ssr: true,
 
   // Global CSS: https://go.nuxtjs.dev/config-css
   css: ['@/assets/scss/vendor/_reset.scss', '@/assets/scss/vendor/_skeleton.scss'],


### PR DESCRIPTION
- Enable SSR to ensure metadata is rendered for crawlers
- Fix Open Graph tags to use 'property' instead of 'name' attribute
- Add og:site_name for better social media sharing
- Add canonical URL link tag for SEO